### PR TITLE
feat(posts): Add like/dislike counts and user reaction status

### DIFF
--- a/server/models/post.go
+++ b/server/models/post.go
@@ -80,6 +80,10 @@ type PostResponse struct {
 	CreatedAt      string         `json:"created_at"`
 	UpdatedAt      sql.NullString `json:"updated_at"`
 	Images         []string       `json:"images"`
+	Likes          int            `json:"likes"`
+	Dislikes       int            `json:"dislikes"`
+	UserLiked      bool           `json:"user_liked"`
+	UserDisliked   bool           `json:"user_disliked"`
 	GroupID        *int64         `json:"group_id,omitempty"`
 	GroupName      *string        `json:"group_name,omitempty"`
 }


### PR DESCRIPTION
Notes:
   - Adds Likes and Dislikes counts to post responses.
   - Adds UserLiked and UserDisliked booleans to indicate the current user's reaction.
   - Updates GetPostByID and GetUserFeed queries to include this new information.

the json includes now like/dislike and user_liked/user_disliked (if the user liked or disliked the post)
```json
	"likes": 1,
	"dislikes": 0,
	"user_liked": false,
	"user_disliked": false
```

Important: need testing